### PR TITLE
[BugFix][UMA] Protect target registration (#13624)

### DIFF
--- a/gallery/tutorial/uma.py
+++ b/gallery/tutorial/uma.py
@@ -57,7 +57,7 @@ testing.utils.install_request_hook(depth=3)
 #
 
 ######################################################################
-# .. image:: https://raw.githubusercontent.com/apache/tvm-site/main/images/tutorial/uma_vanilla_block_diagram.png
+# .. image:: https://raw.githubusercontent.com/tlc-pack/web-data/main/images/tutorial/uma_vanilla_block_diagram.png
 #   :width: 100%
 #   :alt: A block diagram of Vanilla
 #

--- a/python/tvm/relay/backend/contrib/uma/backend.py
+++ b/python/tvm/relay/backend/contrib/uma/backend.py
@@ -278,11 +278,12 @@ class UMABackend(ABC):
         """
         registration_func = tvm.get_global_func("relay.backend.contrib.uma.RegisterTarget")
 
-        for name, attr in self._target_attrs:
+        for name, attr in self._target_attrs.items():
             if attr is None:
                 raise ValueError("Target attribute None is not supported.")
-
-        if registration_func(self.target_name, self._target_attrs):
+        # skip if target is already registered
+        if self.target_name not in tvm.target.Target.list_kinds():
+            registration_func(self.target_name, self._target_attrs)
             self._relay_to_relay.register()
             self._relay_to_tir.register()
             self._tir_to_runtime.register()


### PR DESCRIPTION
This PR address fixes for UMA target registration.
* Fix the doc issue #13304
* Continues stalled PR #12731

Changes:
* Incorporates all proposed fixes from mentioned [PR #12731](https://github.com/apache/tvm/pull/12731)
* Address test case concerns and discussions from [PR #12731](https://github.com/apache/tvm/pull/12731)
* **NEW:** Already exiting target cannot be created, explicit error on this.
* **NEW:** Attributes having special/reserved scope cannot be created explicitly.

It also address proper test cases for all the above.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
